### PR TITLE
Override max-width for container to use all space on screen

### DIFF
--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -11,3 +11,7 @@
 // custom bits
 .date { font-style: italic; color: $gray; }
 
+// theme overrides
+.container {
+    max-width: 90%;
+}


### PR DESCRIPTION
by simply overriding the style provided by jekyll-theme-hacker

@dcantrell is this what you had in mind? 