### PR TITLE
composer-on-rhel: Fix a couple of typos, hyperlinks, and a caution

### DIFF
--- a/_posts/2018-10-08-Pushing-Images-to-AWS.md
+++ b/_posts/2018-10-08-Pushing-Images-to-AWS.md
@@ -13,9 +13,8 @@ partition layout, and include cloud-init.
 
 ## Prerequisites
 
-We'll use [Fedora 29](https://getfedora.org/) as our OS of choice for running this. Run
-this in its own VM with at least 8 gigabytes of memory and 40 gigabytes of disk space.
-[Lorax](http://weldr.io/lorax/) makes some changes to the operating system its running on.
+Run this in its own VM with at least 8 gigabytes of memory and 40 gigabytes of disk space.
+[Lorax](https://weldr.io/lorax/) makes some changes to the operating system its running on.
 
 First install Composer:
 
@@ -39,8 +38,20 @@ If you're going to use [Cockpit](https://cockpit-project.org/) UI to drive Compo
 
 Install the [AWS client](https://aws.amazon.com/cli/) tooling:
 
+Fedora 29+
+
     $ sudo yum install python3-pip
     $ sudo pip3 install awscli
+
+RHEL 7.6+
+
+    $ sudo subscription-manager repos --enable rhel-server-rhscl-7-rpms
+    $ sudo yum install rh-python36-python-pip -y
+    $ sudo scl enable rh-python36 -- pip install awscli
+    $ scl enable rh-python36 bash
+
+Note, with RHEL 7.6 systems, any aws commands following will need to be issued within the
+scl enable wrapper.
 
 Make sure you have an *Access Key ID* configured in
 [AWS IAM account manager](https://aws.amazon.com/iam/) and use that info to configure

--- a/_posts/2018-10-08-Pushing-Images-to-Azure.md
+++ b/_posts/2018-10-08-Pushing-Images-to-Azure.md
@@ -14,9 +14,8 @@ include the necessary agents, as well as
 
 ## Prerequisites
 
-We'll use [Fedora 29](https://getfedora.org/) as our OS of choice for running this. Run
-this in its own VM with at least 8 gigabytes of memory and 40 gigabytes of disk space.
-[Lorax](http://weldr.io/lorax/) makes some changes to the operating system its running on.
+Run this in its own VM with at least 8 gigabytes of memory and 40 gigabytes of disk space.
+[Lorax](https://weldr.io/lorax/) makes some changes to the operating system its running on.
 
 First install Composer:
 
@@ -41,7 +40,7 @@ If you're going to use [Cockpit](https://cockpit-project.org/) UI to drive Compo
 Install the [Azure CLI](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli-yum) tooling:
 
     $ sudo rpm --import https://packages.microsoft.com/keys/microsoft.asc
-    $ sudo sh -c 'echo -e "[azure-cli]\nname=Azure CLI\nbaseurl=https://packages.microsoft.com/yumrepos/azure-cli\nenabled=1\ngpgcheck=1\ngpgkey=https://packages.microsoft.com/keys/microsoft.asc" > /etc/yum.repos.d/azure-cli.repo'
+    $ sudo yum-config-manager --add-repo=https://packages.microsoft.com/yumrepos/azure-cli
     $ sudo yum install azure-cli
 
 Now log into the Azure CLI like so:

--- a/_posts/2018-10-08-Pushing-Images-to-Openstack.md
+++ b/_posts/2018-10-08-Pushing-Images-to-Openstack.md
@@ -13,9 +13,8 @@ layout, and include cloud-init.
 
 ## Prerequisites
 
-We'll use [Fedora 29](https://getfedora.org/) as our OS of choice for running this. Run
-this in its own VM with at least 8 gigabytes of memory and 40 gigabytes of disk space.
-[Lorax](http://weldr.io/lorax/) makes some changes to the operating system its running on.
+Run this in its own VM with at least 8 gigabytes of memory and 40 gigabytes of disk space.
+[Lorax](https://weldr.io/lorax/) makes some changes to the operating system its running on.
 
 First install Composer:
 

--- a/_posts/2018-10-08-Pushing-Images-to-VMWare.md
+++ b/_posts/2018-10-08-Pushing-Images-to-VMWare.md
@@ -13,9 +13,8 @@ have the right format, and include the necessary agents.
 
 ## Prerequisites
 
-We'll use [Fedora 29](https://getfedora.org/) as our OS of choice for running this. Run
-this in its own VM with at least 8 gigabytes of memory and 40 gigabytes of disk space.
-[Lorax](http://weldr.io/lorax/) makes some changes to the operating system its running on.
+Run this in its own VM with at least 8 gigabytes of memory and 40 gigabytes of disk space.
+[Lorax](https://weldr.io/lorax/) makes some changes to the operating system its running on.
 
 First install Composer:
 

--- a/_posts/2018-10-18-Running-Composer-on-RHEL.md
+++ b/_posts/2018-10-18-Running-Composer-on-RHEL.md
@@ -8,7 +8,7 @@ tags: welder-web lorax-composer
 ---
 
 Weldr aka. Composer can generate custom images suitable for deploying systems, or as
-images ready to upload the cloud. It works great on Fedora, but on Red Hat Enterpise Linux
+images ready to upload the cloud. It works great on Fedora, but on Red Hat Enterprise Linux
 there's an additional wrinkle.
 
 Composer uses [Anaconda](https://fedoraproject.org/wiki/Anaconda) and [Lorax](https://weldr.io/lorax/)
@@ -24,9 +24,9 @@ repositories locally and use that as a source of content for Composer.
 
 We'll use [RHEL 7.5](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/7.5_release_notes/index)
  as our version of Red Hat Enterprise Linux for running this document. Make sure to have at
-least 50 gigabytes of disk space to run this. Due to the way [Lorax](http://weldr.io/lorax/) works
+least 50 gigabytes of disk space to run this. Due to the way [Lorax](https://weldr.io/lorax/) works
 it make changes to the operating system its running on, so don't use this system for
-other tasks:
+other tasks. It may be beneficial to deploy [Lorax](https://weldr.io/lorax) in an ephemeral virtual machine.:
 
 Make sure your system is subscribed:
 


### PR DESCRIPTION
Fixing a reference to "Enterpise Linux" and changing the weldr.io
hyperlinks to point to the https:// URI. Since there is a reference to "not
using the system for other workloads", I also included a mention that it
would be best to deploy the utility in a VM.