### PR TITLE
Make docs for pushing images rhel 7.6 friendly

### DIFF
--- a/_posts/2018-10-08-Pushing-Images-to-AWS.md
+++ b/_posts/2018-10-08-Pushing-Images-to-AWS.md
@@ -13,9 +13,8 @@ partition layout, and include cloud-init.
 
 ## Prerequisites
 
-We'll use [Fedora 29](https://getfedora.org/) as our OS of choice for running this. Run
-this in its own VM with at least 8 gigabytes of memory and 40 gigabytes of disk space.
-[Lorax](http://weldr.io/lorax/) makes some changes to the operating system its running on.
+Run this in its own VM with at least 8 gigabytes of memory and 40 gigabytes of disk space.
+[Lorax](https://weldr.io/lorax/) makes some changes to the operating system its running on.
 
 First install Composer:
 
@@ -39,8 +38,20 @@ If you're going to use [Cockpit](https://cockpit-project.org/) UI to drive Compo
 
 Install the [AWS client](https://aws.amazon.com/cli/) tooling:
 
+Fedora 29+
+
     $ sudo yum install python3-pip
     $ sudo pip3 install awscli
+
+RHEL 7.6+
+
+    $ sudo subscription-manager repos --enable rhel-server-rhscl-7-rpms
+    $ sudo yum install rh-python36-python-pip -y
+    $ sudo scl enable rh-python36 -- pip install awscli
+    $ scl enable rh-python36 bash
+
+Note, with RHEL 7.6 systems, any aws commands following will need to be issued within the
+scl enable wrapper.
 
 Make sure you have an *Access Key ID* configured in
 [AWS IAM account manager](https://aws.amazon.com/iam/) and use that info to configure

--- a/_posts/2018-10-08-Pushing-Images-to-Azure.md
+++ b/_posts/2018-10-08-Pushing-Images-to-Azure.md
@@ -14,9 +14,8 @@ include the necessary agents, as well as
 
 ## Prerequisites
 
-We'll use [Fedora 29](https://getfedora.org/) as our OS of choice for running this. Run
-this in its own VM with at least 8 gigabytes of memory and 40 gigabytes of disk space.
-[Lorax](http://weldr.io/lorax/) makes some changes to the operating system its running on.
+Run this in its own VM with at least 8 gigabytes of memory and 40 gigabytes of disk space.
+[Lorax](https://weldr.io/lorax/) makes some changes to the operating system its running on.
 
 First install Composer:
 
@@ -41,7 +40,7 @@ If you're going to use [Cockpit](https://cockpit-project.org/) UI to drive Compo
 Install the [Azure CLI](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli-yum) tooling:
 
     $ sudo rpm --import https://packages.microsoft.com/keys/microsoft.asc
-    $ sudo sh -c 'echo -e "[azure-cli]\nname=Azure CLI\nbaseurl=https://packages.microsoft.com/yumrepos/azure-cli\nenabled=1\ngpgcheck=1\ngpgkey=https://packages.microsoft.com/keys/microsoft.asc" > /etc/yum.repos.d/azure-cli.repo'
+    $ sudo yum-config-manager --add-repo=https://packages.microsoft.com/yumrepos/azure-cli
     $ sudo yum install azure-cli
 
 Now log into the Azure CLI like so:

--- a/_posts/2018-10-08-Pushing-Images-to-Openstack.md
+++ b/_posts/2018-10-08-Pushing-Images-to-Openstack.md
@@ -13,9 +13,8 @@ layout, and include cloud-init.
 
 ## Prerequisites
 
-We'll use [Fedora 29](https://getfedora.org/) as our OS of choice for running this. Run
-this in its own VM with at least 8 gigabytes of memory and 40 gigabytes of disk space.
-[Lorax](http://weldr.io/lorax/) makes some changes to the operating system its running on.
+Run this in its own VM with at least 8 gigabytes of memory and 40 gigabytes of disk space.
+[Lorax](https://weldr.io/lorax/) makes some changes to the operating system its running on.
 
 First install Composer:
 

--- a/_posts/2018-10-08-Pushing-Images-to-VMWare.md
+++ b/_posts/2018-10-08-Pushing-Images-to-VMWare.md
@@ -13,9 +13,8 @@ have the right format, and include the necessary agents.
 
 ## Prerequisites
 
-We'll use [Fedora 29](https://getfedora.org/) as our OS of choice for running this. Run
-this in its own VM with at least 8 gigabytes of memory and 40 gigabytes of disk space.
-[Lorax](http://weldr.io/lorax/) makes some changes to the operating system its running on.
+Run this in its own VM with at least 8 gigabytes of memory and 40 gigabytes of disk space.
+[Lorax](https://weldr.io/lorax/) makes some changes to the operating system its running on.
 
 First install Composer:
 


### PR DESCRIPTION
The previous revisions of these docs indicated that the process should be used on Fedora 29 systems. To make it a little less scary to end users on RHEL 7.6 platforms, this patch set documents steps for RHEL 7.6 where applicable.